### PR TITLE
fix(emarsys): always send cart

### DIFF
--- a/pkg/provider/emarsys/server/template/emarsyswebextendtagdata.go
+++ b/pkg/provider/emarsys/server/template/emarsyswebextendtagdata.go
@@ -153,22 +153,25 @@ function mapEventData() {
       break;
     }
     case 'view_item': {
+      mappedData.cart = serializeItems(eventData.items || []);
       mappedData.view = serializeItem(eventData.items[0] || {}, false);
       break;
     }
     case 'view_item_list': {
+      mappedData.cart = serializeItems(eventData.items || []);
       mappedData.category = eventData.item_list_id;
       break;
     }
     case 'purchase': {
+      mappedData.cart = [];
       mappedData.orderId = eventData.transaction_id;
       mappedData.order = serializeItems(eventData.items || []);
-			if (eventData.tax) {
-				mappedData.order[0].price += eventData.tax;
-			}
-			if (eventData.shipping) {
-				mappedData.order[0].price += eventData.shipping;
-			}
+      if (eventData.tax) {
+        mappedData.order[0].price += eventData.tax;
+      }
+      if (eventData.shipping) {
+        mappedData.order[0].price += eventData.shipping;
+      }
       break;
     }
   }


### PR DESCRIPTION
### Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch

### Description
Emarsys seems to always require the cart since it's not able to combine the events by page_id

### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
